### PR TITLE
Fix unclickable button

### DIFF
--- a/src/components/BeautifulButton.tsx
+++ b/src/components/BeautifulButton.tsx
@@ -11,7 +11,7 @@ export const BeautifulButton = ({
   return (
     <AwesomeButton
       style={{ zIndex: '0' }}
-      ripple={true}
+      ripple={false}
       cssModule={AwesomeButtonStyles}
       type={buttonType}
       disabled={disabled}


### PR DESCRIPTION
The buttons are not clickable because AwesomeButton's ripple feature does not check for TouchEvent's existence before accessing it. The pull request disables the ripple feature until the AwesomeButton fixes the feature.